### PR TITLE
Add Netlify data pipeline and Neon function stubs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,12 @@
 [build]
   command = "npm run build"
   publish = "dist"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
 
 [[redirects]]
   from = "/*"

--- a/netlify/functions/students-db.js
+++ b/netlify/functions/students-db.js
@@ -1,0 +1,129 @@
+import { Pool } from 'pg';
+
+const pool = new Pool({
+  connectionString: process.env.NEON_DATABASE_URL,
+  ssl:
+    process.env.NEON_SSL_DISABLED === 'true'
+      ? false
+      : { rejectUnauthorized: false }
+});
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+function maskForPublicMode(records) {
+  return records.map((record) => ({
+    ad: record.ad ? `${record.ad[0] ?? ''}.` : '',
+    soyad: record.soyad ? `${record.soyad[0] ?? ''}***` : '',
+    sinif: record.sinif ?? null,
+    sube: record.sube ?? null
+  }));
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: corsHeaders };
+  }
+
+  if (!process.env.NEON_DATABASE_URL) {
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'NEON_DATABASE_URL tanımlı değil.' })
+    };
+  }
+
+  try {
+    const url = new URL(event.rawUrl);
+    const qClass = url.searchParams.get('class');
+    const qSection = url.searchParams.get('section');
+    const hasEmail = url.searchParams.get('hasEmail') === 'true';
+    const limit = Math.max(1, Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200));
+    const offset = Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10));
+
+    const conditions = [];
+    const params = [];
+
+    if (qClass) {
+      params.push(qClass);
+      conditions.push(`o.sinif = $${params.length}`);
+    }
+
+    if (qSection) {
+      params.push(qSection.toLowerCase());
+      conditions.push(`lower(o.sube) = $${params.length}`);
+    }
+
+    let sql = `
+      SELECT
+        o.id,
+        o.ad,
+        o.soyad,
+        o.sinif,
+        o.sube,
+        COALESCE(
+          json_agg(
+            json_build_object('alan', c.alan, 'deger', c.deger)
+            ORDER BY c.alan
+          ) FILTER (WHERE c.id IS NOT NULL),
+          '[]'::json
+        ) AS iletisim,
+        COUNT(*) OVER() AS total_count
+      FROM ogrenciler o
+      LEFT JOIN ogrenci_iletisim c ON c.ogrenci_id = o.id
+    `;
+
+    if (conditions.length) {
+      sql += ` WHERE ${conditions.join(' AND ')}`;
+    }
+
+    sql += ' GROUP BY o.id';
+
+    if (hasEmail) {
+      sql += ` HAVING BOOL_OR(c.alan ILIKE '%mail%' AND COALESCE(c.deger, '') <> '')`;
+    }
+
+    sql += ' ORDER BY o.sinif NULLS LAST, o.sube NULLS LAST, o.ad';
+
+    params.push(limit);
+    sql += ` LIMIT $${params.length}`;
+    params.push(offset);
+    sql += ` OFFSET $${params.length}`;
+
+    const { rows } = await pool.query(sql, params);
+
+    const total = rows[0]?.total_count ? Number(rows[0].total_count) : 0;
+    const responseRows = rows.map(({ total_count, ...rest }) => rest);
+    const publicMode = process.env.PUBLIC_MODE === 'true';
+    const rowsForResponse = publicMode ? maskForPublicMode(responseRows) : responseRows;
+
+    return {
+      statusCode: 200,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'public, max-age=30, s-maxage=120'
+      },
+      body: JSON.stringify(
+        {
+          total,
+          limit,
+          offset,
+          rows: rowsForResponse
+        },
+        null,
+        2
+      )
+    };
+  } catch (error) {
+    console.error('students-db function error', error);
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Beklenmeyen bir hata oluştu.' })
+    };
+  }
+}

--- a/netlify/functions/students.js
+++ b/netlify/functions/students.js
@@ -1,0 +1,131 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, '../../public/data');
+const INDEX_FILE = path.join(DATA_DIR, 'ogrenciler.index.json');
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+let cachedData = null;
+let lastLoaded = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+async function loadAllStudents() {
+  const now = Date.now();
+  if (cachedData && now - lastLoaded < CACHE_TTL_MS) {
+    return cachedData;
+  }
+
+  const indexRaw = await fs.readFile(INDEX_FILE, 'utf8');
+  const indexJson = JSON.parse(indexRaw);
+
+  const pageUrls = Array.isArray(indexJson.sayfalar) ? indexJson.sayfalar : [];
+  const pages = await Promise.all(
+    pageUrls.map(async (page) => {
+      if (!page?.url) return [];
+      const filePath = path.join(DATA_DIR, path.basename(page.url));
+      const pageRaw = await fs.readFile(filePath, 'utf8');
+      try {
+        const parsed = JSON.parse(pageRaw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (err) {
+        console.error('Page parse error:', page.url, err);
+        return [];
+      }
+    })
+  );
+
+  const rows = pages.flat();
+  cachedData = { rows, meta: indexJson._meta || {} };
+  lastLoaded = now;
+  return cachedData;
+}
+
+function maskForPublicMode(records) {
+  return records.map((record) => ({
+    ad: record.ad ? `${record.ad[0] ?? ''}.` : '',
+    soyad: record.soyad ? `${record.soyad[0] ?? ''}***` : '',
+    sinif: record.sinif ?? null,
+    sube: record.sube ?? null
+  }));
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: corsHeaders };
+  }
+
+  try {
+    const { rows, meta } = await loadAllStudents();
+    const url = new URL(event.rawUrl);
+    const qClass = url.searchParams.get('class');
+    const qSection = url.searchParams.get('section');
+    const hasEmail = url.searchParams.get('hasEmail') === 'true';
+    const limit = Math.max(1, Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200));
+    const offset = Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10));
+
+    let filtered = rows.slice();
+    if (qClass) {
+      filtered = filtered.filter(
+        (row) => (row.sinif ?? '').toString().toLowerCase() === qClass.toLowerCase()
+      );
+    }
+
+    if (qSection) {
+      filtered = filtered.filter(
+        (row) => (row.sube ?? '').toString().toLowerCase() === qSection.toLowerCase()
+      );
+    }
+
+    if (hasEmail) {
+      filtered = filtered.filter((row) =>
+        Array.isArray(row.iletisim) &&
+        row.iletisim.some(
+          (contact) =>
+            typeof contact?.alan === 'string' &&
+            contact.alan.toLowerCase().includes('mail') &&
+            typeof contact?.deger === 'string' &&
+            contact.deger.trim() !== ''
+        )
+      );
+    }
+
+    const total = filtered.length;
+    const page = filtered.slice(offset, offset + limit);
+    const publicMode = process.env.PUBLIC_MODE === 'true';
+    const rowsForResponse = publicMode ? maskForPublicMode(page) : page;
+
+    return {
+      statusCode: 200,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'public, max-age=60, s-maxage=300, stale-while-revalidate=600'
+      },
+      body: JSON.stringify(
+        {
+          total,
+          limit,
+          offset,
+          meta,
+          rows: rowsForResponse
+        },
+        null,
+        2
+      )
+    };
+  } catch (error) {
+    console.error('students function error', error);
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Beklenmeyen bir hata oluştu.' })
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "lucide-react": "^0.364.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/public/data/ogrenciler.index.json
+++ b/public/data/ogrenciler.index.json
@@ -1,0 +1,13 @@
+{
+  "_meta": {
+    "ver": "1.0.0",
+    "kaynak": "2024-2025 kayıt",
+    "son_guncelleme": "2024-03-01T10:00:00Z",
+    "toplam_kayit": 4,
+    "sayfa_boyutu": 2
+  },
+  "sayfalar": [
+    { "no": 1, "url": "/data/ogrenciler.page-001.json" },
+    { "no": 2, "url": "/data/ogrenciler.page-002.json" }
+  ]
+}

--- a/public/data/ogrenciler.page-001.json
+++ b/public/data/ogrenciler.page-001.json
@@ -1,0 +1,21 @@
+[
+  {
+    "ad": "Ayşe",
+    "soyad": "Yılmaz",
+    "sinif": "9",
+    "sube": "A",
+    "iletisim": [
+      { "alan": "ogrenci_email", "deger": "ayse.yilmaz@example.com" },
+      { "alan": "veli_tel", "deger": "+90 555 111 2233" }
+    ]
+  },
+  {
+    "ad": "Berk",
+    "soyad": "Demir",
+    "sinif": "9",
+    "sube": "B",
+    "iletisim": [
+      { "alan": "ogrenci_email", "deger": "berk.demir@example.com" }
+    ]
+  }
+]

--- a/public/data/ogrenciler.page-002.json
+++ b/public/data/ogrenciler.page-002.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ad": "Cem",
+    "soyad": "Aksoy",
+    "sinif": "10",
+    "sube": "A",
+    "iletisim": [
+      { "alan": "ogrenci_email", "deger": "cem.aksoy@example.com" }
+    ]
+  },
+  {
+    "ad": "Deniz",
+    "soyad": "Kaya",
+    "sinif": "10",
+    "sube": "B",
+    "iletisim": []
+  }
+]

--- a/public/data/schema.json
+++ b/public/data/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ata-akademi.example/schema/ogrenciler.schema.json",
+  "title": "OgrenciKaydi",
+  "type": "object",
+  "required": ["ad", "soyad"],
+  "properties": {
+    "ad": { "type": "string" },
+    "soyad": { "type": "string" },
+    "sinif": { "type": "string" },
+    "sube": { "type": "string" },
+    "iletisim": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["alan", "deger"],
+        "properties": {
+          "alan": { "type": "string" },
+          "deger": { "type": "string" }
+        }
+      }
+    },
+    "_meta": {
+      "type": "object",
+      "properties": {
+        "ver": { "type": "string" },
+        "kaynak": { "type": "string" },
+        "son_guncelleme": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add versioned student dataset schema and sample paginated JSON to the Netlify public folder
- implement a serverless Netlify function to filter static student data with pagination and masking controls
- add a Neon-backed serverless function, update Netlify configuration, and include the pg dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd63afd834832ba35009b3a0b94e59