### PR TITLE
Ensure database schema exists before queries

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -9,6 +9,44 @@ const pool = new Pool({
   }
 });
 
+let initPromise;
+
+async function ensureSchema() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS students (
+          id SERIAL PRIMARY KEY,
+          name TEXT NOT NULL,
+          class TEXT NOT NULL
+        )
+      `);
+
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS attendance (
+          id SERIAL PRIMARY KEY,
+          student_id INTEGER NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+          date DATE NOT NULL,
+          status TEXT NOT NULL,
+          CONSTRAINT unique_attendance UNIQUE (student_id, date)
+        )
+      `);
+
+      await pool.query(`
+        CREATE INDEX IF NOT EXISTS attendance_date_idx ON attendance(date)
+      `);
+    })().catch(error => {
+      initPromise = undefined;
+      throw error;
+    });
+  }
+
+  return initPromise;
+}
+
 module.exports = {
-  query: (text, params) => pool.query(text, params)
+  query: async (text, params) => {
+    await ensureSchema();
+    return pool.query(text, params);
+  }
 };


### PR DESCRIPTION
## Summary
- create the students and attendance tables on demand before processing requests
- add an index to speed up attendance lookups by date

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de3da4de98832b9d41474d594aa0df