### PR TITLE
Configure Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "public"
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration file so builds use the existing npm build command
- point the Vercel output directory to the public folder that contains the static site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e26adb1e50832b86b71e85ed8b874d