### PR TITLE
Preserve original attendance selection on save failure

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -386,11 +386,13 @@
       `;
 
       students.forEach(student => {
+        const originalStatus = student.status || '';
         html += `
           <div class="student-row">
             <span class="student-name">${student.name}</span>
-            <select class="status-select ${student.status}" 
-                    data-id="${student.id}" 
+            <select class="status-select ${student.status}"
+                    data-id="${student.id}"
+                    data-original="${originalStatus}"
                     onchange="saveStatus(this, '${date}')">
               <option value="">Durum Seçin...</option>
               <option value="geldi" ${student.status === 'geldi' ? 'selected' : ''}>✓ Geldi</option>
@@ -444,13 +446,13 @@
     async function saveStatus(select, date) {
       const studentId = select.dataset.id;
       const status = select.value;
-      
+
       if (!status) {
         select.className = 'status-select';
         return;
       }
 
-      const originalValue = select.dataset.original || '';
+      const originalValue = select.dataset.original ?? select.value ?? '';
       select.disabled = true;
 
       try {


### PR DESCRIPTION
## Summary
- add a data-original attribute to attendance status selects so their initial state is tracked
- use the stored original status when saving to restore selections after a failed request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f5bd8214832bb1c551876a0439a5