### PR TITLE
Add Heroku-ready server and attendance enhancements

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node src/server.js

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "ata-akademi-yoklama",
   "version": "1.0.0",
   "description": "Ata Akademi için modern yoklama takip sistemi",
-  "main": "src/index.js",
+  "main": "src/server.js",
   "scripts": {
-    "dev": "netlify dev",
+    "start": "node src/server.js",
+    "dev": "node src/server.js",
     "build": "rm -rf dist && mkdir -p dist && cp -R public/. dist",
     "deploy": "netlify deploy --prod",
     "test": "echo 'Tests not yet implemented'"
@@ -18,8 +19,8 @@
   "author": "Ata Akademi",
   "license": "MIT",
   "dependencies": {
-    "pg": "^8.11.3",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "netlify-cli": "^17.24.0"

--- a/public/index.html
+++ b/public/index.html
@@ -116,17 +116,40 @@
       padding: 30px;
     }
 
+    #notificationArea {
+      display: none;
+      margin-bottom: 20px;
+      gap: 12px;
+    }
+
     .info-box {
       background: #e7f3ff;
       border-left: 4px solid #2196F3;
       padding: 15px;
-      margin-bottom: 20px;
-      border-radius: 4px;
+      border-radius: 6px;
+      color: #0c5460;
+      line-height: 1.5;
     }
 
     .info-box.warning {
       background: #fff3cd;
       border-left-color: #ffc107;
+      color: #856404;
+    }
+
+    .info-box.error {
+      background: #f8d7da;
+      border-left-color: #dc3545;
+      color: #721c24;
+    }
+
+    .info-box ul {
+      margin-top: 10px;
+      padding-left: 20px;
+    }
+
+    .info-box li {
+      margin-bottom: 4px;
     }
 
     .stats {
@@ -295,58 +318,100 @@
         <input type="date" id="dateInput" />
       </div>
 
-      <button class="btn btn-primary" onclick="loadAttendance()">
-        Yoklamayı Getir
-      </button>
+      <button class="btn btn-primary" id="loadButton">Yoklamayı Getir</button>
     </div>
 
     <div class="content">
+      <div id="notificationArea"></div>
       <div id="statsContainer" style="display: none;"></div>
       <div id="attendanceList"></div>
     </div>
   </div>
 
   <script>
-    const classes = [
-      "TYT Sınıfı", "9. Sınıf", "10. Sınıf", 
-      "11 Say 1", "11 Say 2", "11 Ea 1", "11 Ea 2",
-      "12 Say 1", "12 Say 2", "12 Say 3", "12 Ea 1", "12 Ea 2", "12 Ea 3",
-      "Mezun Ea 1", "Mezun Ea 2", "Mezun Ea 3", 
-      "Mezun Say 1", "Mezun Say 2", "Mezun Say 3"
+    const API_BASE = '/api';
+    const VALID_STATUSES = ['geldi', 'gelmedi', 'mazeretli', 'izinli'];
+
+    const defaultClassList = [
+      'TYT Sınıfı', '9. Sınıf', '10. Sınıf',
+      '11 Say 1', '11 Say 2', '11 Ea 1', '11 Ea 2',
+      '12 Say 1', '12 Say 2', '12 Say 3', '12 Ea 1', '12 Ea 2', '12 Ea 3',
+      'Mezun Ea 1', 'Mezun Ea 2', 'Mezun Ea 3',
+      'Mezun Say 1', 'Mezun Say 2', 'Mezun Say 3'
     ];
 
     const classSelect = document.getElementById('classSelect');
     const dateInput = document.getElementById('dateInput');
     const attendanceList = document.getElementById('attendanceList');
     const statsContainer = document.getElementById('statsContainer');
+    const notificationArea = document.getElementById('notificationArea');
+    const loadButton = document.getElementById('loadButton');
 
+    let classCatalog = [];
     let currentStudents = [];
+    let currentMetadata = null;
+    let scheduleNotification = null;
+    let attendanceNotification = null;
 
-    // Sınıf listesi doldur
-    classes.forEach(cls => {
-      const opt = document.createElement('option');
-      opt.value = cls;
-      opt.textContent = cls;
-      classSelect.appendChild(opt);
-    });
+    init();
 
-    // Bugünün tarihini ayarla
-    const today = new Date().toISOString().split('T')[0];
-    dateInput.value = today;
+    async function init() {
+      setToday();
+      await loadClassCatalog();
+      loadButton.addEventListener('click', loadAttendance);
+      classSelect.addEventListener('change', updateScheduleNotification);
+    }
+
+    function setToday() {
+      const today = new Date().toISOString().split('T')[0];
+      dateInput.value = today;
+    }
+
+    async function loadClassCatalog() {
+      try {
+        const res = await fetch(`${API_BASE}/classes`);
+        if (!res.ok) {
+          throw new Error('Sınıf listesi alınamadı');
+        }
+
+        classCatalog = await res.json();
+      } catch (error) {
+        console.warn('Sınıf bilgileri yüklenemedi, varsayılan liste kullanılıyor.', error);
+        classCatalog = defaultClassList.map(name => ({ name, schedule: null, notes: 'Ders programı yakında güncellenecek.' }));
+      }
+
+      populateClassSelect();
+    }
+
+    function populateClassSelect() {
+      classSelect.innerHTML = '<option value="">Sınıf seçin...</option>';
+      classCatalog
+        .map(cls => cls.name)
+        .concat(defaultClassList)
+        .filter((value, index, array) => array.indexOf(value) === index)
+        .forEach(cls => {
+          const opt = document.createElement('option');
+          opt.value = cls;
+          opt.textContent = cls;
+          classSelect.appendChild(opt);
+        });
+    }
 
     async function loadAttendance() {
       const cls = classSelect.value;
       const date = dateInput.value;
-      
+
       if (!cls || !date) {
         showMessage('Lütfen sınıf ve tarih seçin.', 'warning');
         return;
       }
 
       showLoading();
+      attendanceNotification = null;
+      renderNotifications();
 
       try {
-        const res = await fetch(`/attendance?class=${encodeURIComponent(cls)}&date=${date}`);
+        const res = await fetch(`${API_BASE}/attendance?class=${encodeURIComponent(cls)}&date=${date}`);
         const data = await res.json();
 
         if (!res.ok) {
@@ -354,33 +419,42 @@
           return;
         }
 
-        currentStudents = data;
-        displayAttendance(data, cls, date);
-        displayStats(data);
+        currentStudents = data.students || [];
+        currentMetadata = data.metadata || { className: cls, date, total: currentStudents.length };
+
+        if (data.classInfo) {
+          upsertClassInfo(data.classInfo);
+        }
+
+        updateScheduleNotification();
+        updateAttendanceNotification();
+
+        if (currentStudents.length === 0) {
+          showEmptyState();
+          return;
+        }
+
+        displayAttendance(currentStudents, currentMetadata);
+        displayStats(currentStudents);
       } catch (error) {
         showMessage('Bağlantı hatası: ' + error.message, 'error');
       }
     }
 
-    function displayAttendance(students, className, date) {
-      if (students.length === 0) {
-        attendanceList.innerHTML = `
-          <div class="empty-state">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
-            </svg>
-            <h3>Öğrenci Bulunamadı</h3>
-            <p>Bu sınıfta kayıtlı öğrenci bulunmamaktadır.</p>
-          </div>
-        `;
-        statsContainer.style.display = 'none';
-        return;
+    function upsertClassInfo(info) {
+      const index = classCatalog.findIndex(cls => cls.name === info.name);
+      if (index >= 0) {
+        classCatalog[index] = info;
+      } else {
+        classCatalog.push(info);
       }
+    }
 
+    function displayAttendance(students, metadata) {
       let html = `
         <div class="info-box">
-          <strong>${className}</strong> - ${formatDate(date)} 
-          <span style="float: right;">${students.length} Öğrenci</span>
+          <strong>${metadata.className}</strong> - ${formatDate(metadata.date)}
+          <span style="float: right;">${metadata.total || students.length} Öğrenci</span>
         </div>
         <div class="attendance-list">
       `;
@@ -393,7 +467,7 @@
             <select class="status-select ${student.status}"
                     data-id="${student.id}"
                     data-original="${originalStatus}"
-                    onchange="saveStatus(this, '${date}')">
+                    onchange="saveStatus(this, '${metadata.date}')">
               <option value="">Durum Seçin...</option>
               <option value="geldi" ${student.status === 'geldi' ? 'selected' : ''}>✓ Geldi</option>
               <option value="gelmedi" ${student.status === 'gelmedi' ? 'selected' : ''}>✗ Gelmedi</option>
@@ -456,7 +530,7 @@
       select.disabled = true;
 
       try {
-        const res = await fetch('/attendance', {
+        const res = await fetch(`${API_BASE}/attendance`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ studentId, date, status })
@@ -464,21 +538,21 @@
 
         const result = await res.json();
 
-        if (!res.ok) {
-          throw new Error(result.error || 'Kayıt başarısız.');
+        if (!res.ok || !result.success) {
+          throw new Error(result.error || result.message || 'Kayıt başarısız.');
         }
 
         select.className = `status-select ${status}`;
         select.dataset.original = status;
-        
-        // İstatistikleri güncelle
-        const student = currentStudents.find(s => s.id == studentId);
+
+        const student = currentStudents.find(s => `${s.id}` === `${studentId}`);
         if (student) {
           student.status = status;
-          displayStats(currentStudents);
         }
 
-        showToast('✓ Yoklama kaydedildi', 'success');
+        refreshMetadata();
+        displayStats(currentStudents);
+        showToast(result.message || '✓ Yoklama kaydedildi', 'success');
       } catch (error) {
         showToast('✗ ' + error.message, 'error');
         select.value = originalValue;
@@ -486,6 +560,18 @@
       } finally {
         select.disabled = false;
       }
+    }
+
+    function refreshMetadata() {
+      if (!currentMetadata) {
+        return;
+      }
+
+      const recorded = currentStudents.filter(student => VALID_STATUSES.includes(student.status)).length;
+      currentMetadata.recorded = recorded;
+      currentMetadata.total = currentStudents.length;
+      currentMetadata.hasAttendance = recorded > 0;
+      updateAttendanceNotification();
     }
 
     function showLoading() {
@@ -502,6 +588,20 @@
       attendanceList.innerHTML = `
         <div class="info-box ${type}">
           ${message}
+        </div>
+      `;
+      statsContainer.style.display = 'none';
+      renderNotifications();
+    }
+
+    function showEmptyState() {
+      attendanceList.innerHTML = `
+        <div class="empty-state">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
+          </svg>
+          <h3>Öğrenci Bulunamadı</h3>
+          <p>Bu sınıfta kayıtlı öğrenci bulunmamaktadır.</p>
         </div>
       `;
       statsContainer.style.display = 'none';
@@ -530,17 +630,92 @@
       }, 3000);
     }
 
+    function renderNotifications() {
+      const notifications = [scheduleNotification, attendanceNotification].filter(Boolean);
+      if (notifications.length === 0) {
+        notificationArea.style.display = 'none';
+        notificationArea.innerHTML = '';
+        return;
+      }
+
+      notificationArea.innerHTML = notifications
+        .map(item => `<div class="info-box ${item.type || ''}">${item.html || item.message}</div>`)
+        .join('');
+
+      notificationArea.style.display = 'grid';
+    }
+
+    function updateScheduleNotification() {
+      const selectedClass = classSelect.value;
+      if (!selectedClass) {
+        scheduleNotification = null;
+        renderNotifications();
+        return;
+      }
+
+      const info = classCatalog.find(cls => cls.name === selectedClass);
+      if (!info) {
+        scheduleNotification = null;
+        renderNotifications();
+        return;
+      }
+
+      if (info.schedule && Object.keys(info.schedule).length > 0) {
+        const items = Object.entries(info.schedule)
+          .map(([day, count]) => `<li><strong>${day}</strong>: ${count} ders</li>`)
+          .join('');
+
+        const totalText = info.weeklyTotal ? `<p><strong>Haftalık toplam:</strong> ${info.weeklyTotal} ders</p>` : '';
+
+        scheduleNotification = {
+          type: 'info',
+          html: `
+            <strong>${info.name}</strong> sınıfı ders programı:
+            <ul>${items}</ul>
+            ${totalText}
+            <p>${info.notes || ''}</p>
+          `
+        };
+      } else {
+        scheduleNotification = {
+          type: 'warning',
+          message: info.notes || 'Ders programı yakında güncellenecek.'
+        };
+      }
+
+      renderNotifications();
+    }
+
+    function updateAttendanceNotification() {
+      if (!currentMetadata || !currentMetadata.hasAttendance) {
+        attendanceNotification = null;
+        renderNotifications();
+        return;
+      }
+
+      const recorded = currentMetadata.recorded || 0;
+      const total = currentMetadata.total || currentStudents.length;
+      const dateText = formatDate(currentMetadata.date);
+      attendanceNotification = {
+        type: 'warning',
+        message: `${dateText} tarihine ait ${recorded}/${total} öğrencinin yoklama kaydı mevcut. Güncelleme yapabilirsiniz.`
+      };
+
+      renderNotifications();
+    }
+
     function formatDate(dateStr) {
       const date = new Date(dateStr + 'T00:00:00');
-      return date.toLocaleDateString('tr-TR', { 
-        weekday: 'long', 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
+      return date.toLocaleDateString('tr-TR', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
       });
     }
 
-    // CSS animasyonları
+    window.saveStatus = saveStatus;
+
     const style = document.createElement('style');
     style.textContent = `
       @keyframes slideIn {

--- a/src/db.js
+++ b/src/db.js
@@ -2,20 +2,24 @@
 require('dotenv').config();
 const { Pool } = require('pg');
 
-const hasDatabase = Boolean(process.env.DATABASE_URL);
+const databaseUrl =
+  process.env.DATABASE_URL ||
+  process.env.NEON_DATABASE_URL ||
+  process.env.PG_CONNECTION_STRING ||
+  process.env.POSTGRES_URL;
+
+const hasDatabase = Boolean(databaseUrl);
 
 let pool;
 if (hasDatabase) {
   const poolConfig = {
-    connectionString: process.env.DATABASE_URL
+    connectionString: databaseUrl
   };
 
-  // Production ortamlarında SSL gerekli olabilir. Yerel geliştirmede
-  // "DATABASE_SSL=false" tanımlanarak devre dışı bırakılabilir.
   const shouldUseSSL = process.env.DATABASE_SSL !== 'false';
   if (shouldUseSSL) {
     poolConfig.ssl = {
-      rejectUnauthorized: false // Neon ile uyumlu
+      rejectUnauthorized: false
     };
   }
 
@@ -23,8 +27,9 @@ if (hasDatabase) {
 }
 
 let initPromise;
+let studentSchemaPromise;
 
-async function ensureSchema() {
+async function ensureDatabase() {
   if (!hasDatabase) {
     return;
   }
@@ -32,25 +37,23 @@ async function ensureSchema() {
   if (!initPromise) {
     initPromise = (async () => {
       await pool.query(`
-        CREATE TABLE IF NOT EXISTS students (
-          id SERIAL PRIMARY KEY,
-          name TEXT NOT NULL,
-          class TEXT NOT NULL
-        )
-      `);
-
-      await pool.query(`
         CREATE TABLE IF NOT EXISTS attendance (
           id SERIAL PRIMARY KEY,
-          student_id INTEGER NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+          student_id TEXT NOT NULL,
           date DATE NOT NULL,
-          status TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN ('geldi', 'gelmedi', 'mazeretli', 'izinli')),
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
           CONSTRAINT unique_attendance UNIQUE (student_id, date)
         )
       `);
 
       await pool.query(`
         CREATE INDEX IF NOT EXISTS attendance_date_idx ON attendance(date)
+      `);
+
+      await pool.query(`
+        CREATE INDEX IF NOT EXISTS attendance_student_idx ON attendance(student_id)
       `);
     })().catch(error => {
       initPromise = undefined;
@@ -61,14 +64,76 @@ async function ensureSchema() {
   return initPromise;
 }
 
+async function getStudentSchema() {
+  if (!hasDatabase) {
+    return null;
+  }
+
+  if (!studentSchemaPromise) {
+    studentSchemaPromise = (async () => {
+      await ensureDatabase();
+
+      const { rows } = await pool.query(`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'students'
+      `);
+
+      const columns = rows.map(row => row.column_name.toLowerCase());
+
+      const idColumn =
+        (columns.includes('id') && 'id') ||
+        (columns.includes('student_id') && 'student_id');
+
+      if (!idColumn) {
+        throw new Error('Students tablosunda birincil anahtar kolonu bulunamadı.');
+      }
+
+      const nameColumn =
+        (columns.includes('name') && 'name') ||
+        (columns.includes('full_name') && 'full_name') ||
+        (columns.includes('student_name') && 'student_name') ||
+        (columns.includes('adsoyad') && 'adsoyad');
+
+      if (!nameColumn) {
+        throw new Error('Students tablosunda öğrenci adı için uygun bir kolon bulunamadı.');
+      }
+
+      const classColumn =
+        (columns.includes('class') && 'class') ||
+        (columns.includes('class_name') && 'class_name') ||
+        (columns.includes('sinif') && 'sinif') ||
+        (columns.includes('group_name') && 'group_name');
+
+      if (!classColumn) {
+        throw new Error('Students tablosunda sınıf kolonu bulunamadı.');
+      }
+
+      return {
+        idColumn,
+        nameColumn,
+        classColumn,
+        orderColumn: nameColumn
+      };
+    })().catch(error => {
+      studentSchemaPromise = undefined;
+      throw error;
+    });
+  }
+
+  return studentSchemaPromise;
+}
+
 module.exports = {
   hasDatabase,
+  ensureDatabase,
+  getStudentSchema,
   query: async (text, params) => {
     if (!hasDatabase) {
       throw new Error('DATABASE_URL ayarlanmadığı için veritabanına bağlanılamıyor.');
     }
 
-    await ensureSchema();
+    await ensureDatabase();
     return pool.query(text, params);
   }
 };

--- a/src/functions/attendance.js
+++ b/src/functions/attendance.js
@@ -1,77 +1,19 @@
-// src/functions/attendance.js
-const db = require('../db');
+const {
+  VALID_STATUSES,
+  getClassInfo,
+  getStudentsWithAttendance,
+  saveAttendance,
+  deleteAttendance
+} = require('../services/attendanceService');
 
-const classes = [
-  "TYT Sınıfı", "9. Sınıf", "10. Sınıf", "11 Say 1", "11 Say 2", "11 Ea 1", "11 Ea 2",
-  "12 Say 1", "12 Say 2", "12 Say 3", "12 Ea 1", "12 Ea 2", "12 Ea 3",
-  "Mezun Ea 1", "Mezun Ea 2", "Mezun Ea 3", "Mezun Say 1", "Mezun Say 2", "Mezun Say 3"
-];
+const headers = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
 
-const fallbackStudents = classes.flatMap((className, classIndex) =>
-  Array.from({ length: 5 }, (_, idx) => ({
-    id: classIndex * 100 + idx + 1,
-    name: `${className} Öğrenci ${idx + 1}`,
-    class: className
-  }))
-);
-
-const fallbackAttendance = new Map();
-
-let fallbackActive = !db.hasDatabase;
-
-function getFallbackKey(studentId, date) {
-  return `${studentId}::${date}`;
-}
-
-function ensureFallbackNotice() {
-  if (fallbackActive && !ensureFallbackNotice.notified) {
-    console.warn('Veritabanına ulaşılamadığı için yoklama verileri bellek üzerinde tutuluyor.');
-    ensureFallbackNotice.notified = true;
-  }
-}
-
-ensureFallbackNotice.notified = false;
-
-function isConnectionIssue(error) {
-  const connectionErrorCodes = new Set(['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN', 'ENETUNREACH']);
-  if (!error) {
-    return false;
-  }
-
-  if (error.code && connectionErrorCodes.has(error.code)) {
-    return true;
-  }
-
-  if (Array.isArray(error.errors) && error.errors.some(inner => connectionErrorCodes.has(inner.code))) {
-    return true;
-  }
-
-  if (typeof error[Symbol.iterator] === 'function') {
-    for (const inner of error) {
-      if (inner && connectionErrorCodes.has(inner.code)) {
-        return true;
-      }
-    }
-  }
-
-  const message = (error.message || '').toString();
-  return [...connectionErrorCodes].some(code => message.includes(code));
-}
-
-function activateFallback(error) {
-  fallbackActive = true;
-  ensureFallbackNotice();
-  console.warn('Veritabanı bağlantısı hatası nedeniyle geçici hafıza moduna geçildi.', error);
-}
-
-exports.handler = async (event, context) => {
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type'
-  };
-
+exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers, body: '' };
   }
@@ -79,197 +21,98 @@ exports.handler = async (event, context) => {
   try {
     if (event.httpMethod === 'GET') {
       const { class: className, date } = event.queryStringParameters || {};
-      
+
       if (!className || !date) {
-        return { 
-          statusCode: 400, 
-          headers, 
-          body: JSON.stringify({ error: 'Sınıf ve tarih zorunlu.' }) 
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Sınıf ve tarih zorunludur.' })
         };
       }
 
-      if (!fallbackActive) {
-        try {
-          // Öğrenci listesi + yoklama durumu
-          const students = await db.query(
-            `SELECT s.id, s.name, s.class,
-                    COALESCE(a.status, '') as status,
-                    a.id as attendance_id
-             FROM students s
-             LEFT JOIN attendance a ON s.id = a.student_id AND a.date = $1
-             WHERE s.class = $2
-             ORDER BY s.name`,
-            [date, className]
-          );
-
-          return {
-            statusCode: 200,
-            headers,
-            body: JSON.stringify(students.rows)
-          };
-        } catch (error) {
-          if (isConnectionIssue(error)) {
-            activateFallback(error);
-          } else {
-            throw error;
-          }
-        }
-      }
-
-      ensureFallbackNotice();
-
-      const students = fallbackStudents
-        .filter(student => student.class === className)
-        .map(student => {
-          const key = getFallbackKey(student.id, date);
-          const status = fallbackAttendance.get(key) || '';
-          return {
-            ...student,
-            status,
-            attendance_id: status ? key : null
-          };
-        });
+      const students = await getStudentsWithAttendance(className, date);
+      const recordedCount = students.filter(student => VALID_STATUSES.includes(student.status)).length;
 
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify(students)
+        body: JSON.stringify({
+          students,
+          metadata: {
+            className,
+            date,
+            total: students.length,
+            recorded: recordedCount,
+            hasAttendance: recordedCount > 0
+          },
+          classInfo: getClassInfo(className)
+        })
       };
     }
 
     if (event.httpMethod === 'POST') {
-      const body = JSON.parse(event.body);
+      const body = JSON.parse(event.body || '{}');
       const { studentId, date, status } = body;
 
       if (!studentId || !date || !status) {
-        return { 
-          statusCode: 400, 
-          headers, 
-          body: JSON.stringify({ error: 'Eksik veri.' }) 
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Öğrenci, tarih ve durum bilgileri zorunludur.' })
         };
       }
 
-      // Status kontrolü
-      const validStatuses = ['geldi', 'gelmedi', 'mazeretli', 'izinli'];
-      if (!validStatuses.includes(status)) {
-        return { 
-          statusCode: 400, 
-          headers, 
-          body: JSON.stringify({ error: 'Geçersiz durum.' }) 
+      if (!VALID_STATUSES.includes(status)) {
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Geçersiz yoklama durumu.' })
         };
       }
 
-      if (!fallbackActive) {
-        try {
-          // Mevcut kayıt kontrolü
-          const existing = await db.query(
-            'SELECT id FROM attendance WHERE student_id = $1 AND date = $2',
-            [studentId, date]
-          );
-
-          if (existing.rows.length > 0) {
-            // Güncelle
-            await db.query(
-              'UPDATE attendance SET status = $1 WHERE student_id = $2 AND date = $3',
-              [status, studentId, date]
-            );
-
-            return {
-              statusCode: 200,
-              headers,
-              body: JSON.stringify({ success: true, message: 'Yoklama güncellendi.' })
-            };
-          }
-
-          // Yeni kayıt ekle
-          await db.query(
-            'INSERT INTO attendance (student_id, date, status) VALUES ($1, $2, $3)',
-            [studentId, date, status]
-          );
-
-          return {
-            statusCode: 201,
-            headers,
-            body: JSON.stringify({ success: true, message: 'Yoklama kaydedildi.' })
-          };
-        } catch (error) {
-          if (isConnectionIssue(error)) {
-            activateFallback(error);
-          } else {
-            throw error;
-          }
-        }
-      }
-
-      ensureFallbackNotice();
-      const key = getFallbackKey(studentId, date);
-      fallbackAttendance.set(key, status);
+      const result = await saveAttendance(studentId, date, status);
 
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify({ success: true, message: 'Yoklama kaydedildi (geçici hafıza).' })
+        body: JSON.stringify({ success: true, ...result })
       };
     }
 
     if (event.httpMethod === 'DELETE') {
-      const body = JSON.parse(event.body);
+      const body = JSON.parse(event.body || '{}');
       const { studentId, date } = body;
 
       if (!studentId || !date) {
-        return { 
-          statusCode: 400, 
-          headers, 
-          body: JSON.stringify({ error: 'Eksik veri.' }) 
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Öğrenci ve tarih bilgileri zorunludur.' })
         };
       }
 
-      if (!fallbackActive) {
-        try {
-          await db.query(
-            'DELETE FROM attendance WHERE student_id = $1 AND date = $2',
-            [studentId, date]
-          );
-
-          return {
-            statusCode: 200,
-            headers,
-            body: JSON.stringify({ success: true, message: 'Yoklama silindi.' })
-          };
-        } catch (error) {
-          if (isConnectionIssue(error)) {
-            activateFallback(error);
-          } else {
-            throw error;
-          }
-        }
-      }
-
-      ensureFallbackNotice();
-      const key = getFallbackKey(studentId, date);
-      fallbackAttendance.delete(key);
+      const result = await deleteAttendance(studentId, date);
 
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify({ success: true, message: 'Yoklama silindi (geçici hafıza).' })
+        body: JSON.stringify({ success: true, ...result })
       };
     }
 
-    return { 
-      statusCode: 405, 
-      headers, 
-      body: JSON.stringify({ error: 'Method not allowed' }) 
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' })
     };
-
   } catch (error) {
-    console.error('DB Error:', error);
+    console.error('Attendance API error:', error);
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ 
-        error: 'Sunucu hatası', 
-        details: process.env.NODE_ENV === 'development' ? error.message : undefined 
+      body: JSON.stringify({
+        error: 'Sunucu hatası',
+        details: process.env.NODE_ENV === 'development' ? error.message : undefined
       })
     };
   }

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,223 @@
+require('dotenv').config();
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const { URL } = require('url');
+const {
+  VALID_STATUSES,
+  getClasses,
+  getClassInfo,
+  getStudentsWithAttendance,
+  saveAttendance,
+  deleteAttendance
+} = require('./services/attendanceService');
+
+const PORT = process.env.PORT || 3000;
+const HOST = '0.0.0.0';
+const publicDir = path.join(__dirname, '..', 'public');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon'
+};
+
+function sendJson(res, statusCode, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(body);
+}
+
+function handleOptions(res) {
+  res.writeHead(200, {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end();
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk;
+      if (data.length > 1e6) {
+        req.destroy();
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!data) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(new Error('Geçersiz JSON gövdesi'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function handleApiRequest(req, res, parsedUrl) {
+  const pathname = parsedUrl.pathname;
+
+  if (req.method === 'OPTIONS') {
+    handleOptions(res);
+    return true;
+  }
+
+  try {
+    if (pathname === '/api/health' && req.method === 'GET') {
+      sendJson(res, 200, { status: 'ok' });
+      return true;
+    }
+
+    if (pathname === '/api/classes' && req.method === 'GET') {
+      sendJson(res, 200, getClasses());
+      return true;
+    }
+
+    if (pathname === '/api/attendance' && req.method === 'GET') {
+      const className = parsedUrl.searchParams.get('class');
+      const date = parsedUrl.searchParams.get('date');
+
+      if (!className || !date) {
+        sendJson(res, 400, { error: 'Sınıf ve tarih zorunludur.' });
+        return true;
+      }
+
+      const students = await getStudentsWithAttendance(className, date);
+      const recordedCount = students.filter(student => VALID_STATUSES.includes(student.status)).length;
+
+      sendJson(res, 200, {
+        students,
+        metadata: {
+          className,
+          date,
+          total: students.length,
+          recorded: recordedCount,
+          hasAttendance: recordedCount > 0
+        },
+        classInfo: getClassInfo(className)
+      });
+      return true;
+    }
+
+    if (pathname === '/api/attendance' && req.method === 'POST') {
+      const body = await readRequestBody(req);
+      const { studentId, date, status } = body;
+
+      if (!studentId || !date || !status) {
+        sendJson(res, 400, { error: 'Öğrenci, tarih ve durum bilgileri zorunludur.' });
+        return true;
+      }
+
+      if (!VALID_STATUSES.includes(status)) {
+        sendJson(res, 400, { error: 'Geçersiz yoklama durumu.' });
+        return true;
+      }
+
+      const result = await saveAttendance(studentId, date, status);
+      sendJson(res, 200, { success: true, ...result });
+      return true;
+    }
+
+    if (pathname === '/api/attendance' && req.method === 'DELETE') {
+      const body = await readRequestBody(req);
+      const { studentId, date } = body;
+
+      if (!studentId || !date) {
+        sendJson(res, 400, { error: 'Öğrenci ve tarih bilgileri zorunludur.' });
+        return true;
+      }
+
+      const result = await deleteAttendance(studentId, date);
+      sendJson(res, 200, { success: true, ...result });
+      return true;
+    }
+  } catch (error) {
+    console.error('API hata:', error);
+    sendJson(res, 500, {
+      error: 'Sunucu hatası',
+      details: process.env.NODE_ENV === 'development' ? error.message : undefined
+    });
+    return true;
+  }
+
+  return false;
+}
+
+function serveStaticFile(res, filePath) {
+  fs.readFile(filePath, (error, content) => {
+    if (error) {
+      if (error.code === 'ENOENT') {
+        // SPA fallback
+        const indexPath = path.join(publicDir, 'index.html');
+        fs.readFile(indexPath, (indexErr, indexContent) => {
+          if (indexErr) {
+            res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+            res.end('Sunucu hatası');
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.end(indexContent);
+        });
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Sunucu hatası');
+      }
+      return;
+    }
+
+    const ext = path.extname(filePath);
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+
+  if (parsedUrl.pathname.startsWith('/api/')) {
+    const handled = await handleApiRequest(req, res, parsedUrl);
+    if (handled) {
+      return;
+    }
+    sendJson(res, 404, { error: 'Bulunamadı' });
+    return;
+  }
+
+  let safePath = path.normalize(parsedUrl.pathname).replace(/^\/+/, '');
+  if (safePath.endsWith('/')) {
+    safePath += 'index.html';
+  }
+
+  const filePath = path.join(publicDir, safePath || 'index.html');
+  if (!filePath.startsWith(publicDir)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Erişim reddedildi');
+    return;
+  }
+
+  serveStaticFile(res, filePath);
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Ata Akademi yoklama sunucusu ${HOST}:${PORT} üzerinde çalışıyor.`);
+});

--- a/src/services/attendanceService.js
+++ b/src/services/attendanceService.js
@@ -1,0 +1,331 @@
+const db = require('../db');
+
+const CLASS_LIST = [
+  'TYT Sınıfı',
+  '9. Sınıf',
+  '10. Sınıf',
+  '11 Say 1',
+  '11 Say 2',
+  '11 Ea 1',
+  '11 Ea 2',
+  '12 Say 1',
+  '12 Say 2',
+  '12 Say 3',
+  '12 Ea 1',
+  '12 Ea 2',
+  '12 Ea 3',
+  'Mezun Ea 1',
+  'Mezun Ea 2',
+  'Mezun Ea 3',
+  'Mezun Say 1',
+  'Mezun Say 2',
+  'Mezun Say 3'
+];
+
+const SCHEDULE_RULES = [
+  {
+    test: name => name.toLowerCase().includes('mezun'),
+    schedule: {
+      Pazartesi: 6,
+      Salı: 6,
+      Perşembe: 6,
+      Cuma: 6
+    },
+    notes: 'Mezun grupları hafta içi dört gün boyunca altışar ders yapar.'
+  },
+  {
+    test: name => name.startsWith('12'),
+    schedule: {
+      Salı: 4,
+      Perşembe: 4,
+      Cumartesi: 6,
+      Pazar: 6
+    },
+    notes: '12. sınıflar hafta içi iki gün dört, hafta sonu iki gün altı ders yapar.'
+  },
+  {
+    test: name => name.startsWith('10'),
+    schedule: {
+      Salı: 4,
+      Perşembe: 4
+    },
+    notes: '10. sınıflar salı ve perşembe günleri dörder ders yapar.'
+  },
+  {
+    test: name => name.startsWith('9'),
+    schedule: {
+      Cumartesi: 4,
+      Pazar: 4
+    },
+    notes: '9. sınıflar hafta sonları dörder ders yapar.'
+  },
+  {
+    test: name => name === 'TYT Sınıfı',
+    schedule: {
+      Cumartesi: 6,
+      Pazar: 4
+    },
+    notes: 'TYT sınıfı hafta sonu cumartesi altı, pazar dört ders yapar.'
+  }
+];
+
+const DEFAULT_SCHEDULE_NOTE = 'Ders programı henüz tanımlanmadı. Danışmanınızla iletişime geçebilirsiniz.';
+
+const VALID_STATUSES = ['geldi', 'gelmedi', 'mazeretli', 'izinli'];
+
+const fallbackStudents = CLASS_LIST.flatMap((className, classIndex) =>
+  Array.from({ length: 5 }, (_, idx) => ({
+    id: `${classIndex * 100 + idx + 1}`,
+    name: `${className} Öğrenci ${idx + 1}`,
+    class: className
+  }))
+);
+
+const fallbackAttendance = new Map();
+
+let fallbackActive = !db.hasDatabase;
+
+function getFallbackKey(studentId, date) {
+  return `${studentId}::${date}`;
+}
+
+function ensureFallbackNotice() {
+  if (fallbackActive && !ensureFallbackNotice.notified) {
+    console.warn('Veritabanına ulaşılamadığı için yoklama verileri bellek üzerinde tutuluyor.');
+    ensureFallbackNotice.notified = true;
+  }
+}
+
+ensureFallbackNotice.notified = false;
+
+function isConnectionIssue(error) {
+  const connectionErrorCodes = new Set(['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN', 'ENETUNREACH']);
+  if (!error) {
+    return false;
+  }
+
+  if (error.code && connectionErrorCodes.has(error.code)) {
+    return true;
+  }
+
+  if (Array.isArray(error.errors) && error.errors.some(inner => connectionErrorCodes.has(inner.code))) {
+    return true;
+  }
+
+  if (typeof error[Symbol.iterator] === 'function') {
+    for (const inner of error) {
+      if (inner && connectionErrorCodes.has(inner.code)) {
+        return true;
+      }
+    }
+  }
+
+  const message = (error.message || '').toString();
+  return [...connectionErrorCodes].some(code => message.includes(code));
+}
+
+function activateFallback(error) {
+  fallbackActive = true;
+  ensureFallbackNotice();
+  console.warn('Veritabanı bağlantısı hatası nedeniyle geçici hafıza moduna geçildi.', error);
+}
+
+function getClassInfo(name) {
+  const rule = SCHEDULE_RULES.find(({ test }) => test(name));
+  const schedule = rule ? rule.schedule : null;
+  const notes = rule ? rule.notes : DEFAULT_SCHEDULE_NOTE;
+  const weeklyTotal = schedule
+    ? Object.values(schedule).reduce((total, count) => total + Number(count || 0), 0)
+    : 0;
+
+  return {
+    name,
+    schedule,
+    notes,
+    weeklyTotal
+  };
+}
+
+function getClasses() {
+  return CLASS_LIST.map(getClassInfo);
+}
+
+async function fetchStudentsFromDatabase(className, date) {
+  const schema = await db.getStudentSchema();
+  if (!schema) {
+    return [];
+  }
+
+  const { idColumn, nameColumn, classColumn, orderColumn } = schema;
+  const query = `
+    SELECT
+      s.${idColumn}::text AS id,
+      s.${nameColumn} AS name,
+      s.${classColumn} AS class,
+      COALESCE(a.status, '') AS status
+    FROM students s
+    LEFT JOIN attendance a
+      ON s.${idColumn}::text = a.student_id AND a.date = $1
+    WHERE s.${classColumn} = $2
+    ORDER BY s.${orderColumn}
+  `;
+
+  const { rows } = await db.query(query, [date, className]);
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    class: row.class,
+    status: row.status || ''
+  }));
+}
+
+async function getStudentsWithAttendance(className, date) {
+  if (!className || !date) {
+    throw new Error('Sınıf ve tarih bilgileri zorunludur.');
+  }
+
+  if (!fallbackActive) {
+    try {
+      const students = await fetchStudentsFromDatabase(className, date);
+      return students;
+    } catch (error) {
+      if (isConnectionIssue(error)) {
+        activateFallback(error);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  ensureFallbackNotice();
+
+  return fallbackStudents
+    .filter(student => student.class === className)
+    .map(student => {
+      const key = getFallbackKey(student.id, date);
+      const status = fallbackAttendance.get(key) || '';
+      return {
+        ...student,
+        status
+      };
+    });
+}
+
+async function saveAttendance(studentId, date, status) {
+  if (!VALID_STATUSES.includes(status)) {
+    throw new Error('Geçersiz yoklama durumu.');
+  }
+
+  const normalizedId = `${studentId}`;
+
+  if (!fallbackActive) {
+    try {
+      const existing = await db.query(
+        'SELECT id, status FROM attendance WHERE student_id = $1 AND date = $2',
+        [normalizedId, date]
+      );
+
+      if (existing.rows.length > 0) {
+        const current = existing.rows[0];
+        if (current.status === status) {
+          return {
+            operation: 'unchanged',
+            message: 'Yoklama zaten bu durum ile kayıtlı.'
+          };
+        }
+
+        await db.query(
+          'UPDATE attendance SET status = $1, updated_at = NOW() WHERE student_id = $2 AND date = $3',
+          [status, normalizedId, date]
+        );
+
+        return {
+          operation: 'updated',
+          message: 'Yoklama güncellendi.'
+        };
+      }
+
+      await db.query(
+        'INSERT INTO attendance (student_id, date, status) VALUES ($1, $2, $3)',
+        [normalizedId, date, status]
+      );
+
+      return {
+        operation: 'created',
+        message: 'Yoklama kaydedildi.'
+      };
+    } catch (error) {
+      if (isConnectionIssue(error)) {
+        activateFallback(error);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  ensureFallbackNotice();
+
+  const key = getFallbackKey(normalizedId, date);
+  const previous = fallbackAttendance.get(key);
+  fallbackAttendance.set(key, status);
+
+  if (previous === status) {
+    return {
+      operation: 'unchanged',
+      message: 'Yoklama zaten bu durum ile kayıtlı (geçici hafıza).'
+    };
+  }
+
+  return {
+    operation: previous ? 'updated' : 'created',
+    message: previous
+      ? 'Yoklama güncellendi (geçici hafıza).'
+      : 'Yoklama kaydedildi (geçici hafıza).'
+  };
+}
+
+async function deleteAttendance(studentId, date) {
+  const normalizedId = `${studentId}`;
+
+  if (!fallbackActive) {
+    try {
+      await db.query(
+        'DELETE FROM attendance WHERE student_id = $1 AND date = $2',
+        [normalizedId, date]
+      );
+
+      return {
+        success: true,
+        message: 'Yoklama silindi.'
+      };
+    } catch (error) {
+      if (isConnectionIssue(error)) {
+        activateFallback(error);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  ensureFallbackNotice();
+
+  const key = getFallbackKey(normalizedId, date);
+  const existed = fallbackAttendance.delete(key);
+
+  return {
+    success: existed,
+    message: existed
+      ? 'Yoklama silindi (geçici hafıza).'
+      : 'Kayıt bulunamadı (geçici hafıza).'
+  };
+}
+
+module.exports = {
+  CLASS_LIST,
+  VALID_STATUSES,
+  getClassInfo,
+  getClasses,
+  getStudentsWithAttendance,
+  saveAttendance,
+  deleteAttendance
+};


### PR DESCRIPTION
## Summary
- add a lightweight Node HTTP server and Procfile for Heroku deployment while serving the static client and API
- centralize attendance data access with Neon-aware service logic and scheduling metadata for each class
- refresh the frontend to consume the new API, surface class timetables, and warn when attendance already exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f72c2330832b9fe39a225a80421e