### PR TITLE
Add reporting page with navigation support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,16 +31,45 @@
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
       color: white;
       padding: 30px;
-      text-align: center;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 15px;
     }
 
-    .header h1 {
+    .header-left h1 {
       font-size: 2em;
       margin-bottom: 5px;
     }
 
-    .header p {
+    .header-left p {
       opacity: 0.9;
+    }
+
+    .header-nav {
+      display: flex;
+      gap: 10px;
+    }
+
+    .nav-btn {
+      padding: 10px 20px;
+      background: rgba(255,255,255,0.2);
+      border: 2px solid white;
+      color: white;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 600;
+      transition: all 0.3s;
+      text-decoration: none;
+      display: inline-block;
+    }
+
+    .nav-btn:hover,
+    .nav-btn.active {
+      background: white;
+      color: #667eea;
     }
 
     .controls {
@@ -51,6 +80,17 @@
       gap: 15px;
       flex-wrap: wrap;
       align-items: end;
+    }
+
+    @media (max-width: 768px) {
+      .header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .header-nav {
+        justify-content: center;
+      }
     }
 
     .form-group {
@@ -301,8 +341,14 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>🎓 Ata Akademi</h1>
-      <p>Yoklama Takip Sistemi</p>
+      <div class="header-left">
+        <h1>🎓 Ata Akademi</h1>
+        <p>Yoklama Takip Sistemi</p>
+      </div>
+      <div class="header-nav">
+        <a href="index.html" class="nav-btn active">📝 Yoklama</a>
+        <a href="raporlar.html" class="nav-btn">📊 Raporlar</a>
+      </div>
     </div>
 
     <div class="controls">

--- a/public/raporlar.html
+++ b/public/raporlar.html
@@ -1,0 +1,881 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ata Akademi - Raporlama Sistemi</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .container {
+      max-width: 1400px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+      overflow: hidden;
+    }
+
+    .header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 30px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 15px;
+    }
+
+    .header-left h1 {
+      font-size: 2em;
+      margin-bottom: 5px;
+    }
+
+    .header-left p {
+      opacity: 0.9;
+    }
+
+    .header-nav {
+      display: flex;
+      gap: 10px;
+    }
+
+    .nav-btn {
+      padding: 10px 20px;
+      background: rgba(255,255,255,0.2);
+      border: 2px solid white;
+      color: white;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 600;
+      transition: all 0.3s;
+      text-decoration: none;
+      display: inline-block;
+    }
+
+    .nav-btn:hover,
+    .nav-btn.active {
+      background: white;
+      color: #667eea;
+    }
+
+    .filters {
+      padding: 30px;
+      background: #f8f9fa;
+      border-bottom: 2px solid #dee2e6;
+    }
+
+    .filter-row {
+      display: flex;
+      gap: 15px;
+      flex-wrap: wrap;
+      align-items: end;
+      margin-bottom: 15px;
+    }
+
+    .form-group {
+      flex: 1;
+      min-width: 200px;
+    }
+
+    .form-group label {
+      display: block;
+      margin-bottom: 8px;
+      font-weight: 600;
+      color: #495057;
+    }
+
+    select, input[type="date"] {
+      width: 100%;
+      padding: 12px;
+      border: 2px solid #dee2e6;
+      border-radius: 8px;
+      font-size: 14px;
+      transition: all 0.3s;
+    }
+
+    select:focus, input[type="date"]:focus {
+      outline: none;
+      border-color: #667eea;
+      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    }
+
+    .btn {
+      padding: 12px 30px;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.3s;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
+    }
+
+    .btn-secondary {
+      background: #6c757d;
+      color: white;
+    }
+
+    .btn-secondary:hover {
+      background: #5a6268;
+      transform: translateY(-2px);
+    }
+
+    .btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    .content {
+      padding: 30px;
+    }
+
+    .dashboard-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 20px;
+      margin-bottom: 30px;
+    }
+
+    .stat-card {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 25px;
+      border-radius: 12px;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+      transition: transform 0.3s;
+    }
+
+    .stat-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+    }
+
+    .stat-card .icon {
+      font-size: 2.5em;
+      margin-bottom: 10px;
+      opacity: 0.9;
+    }
+
+    .stat-card .number {
+      font-size: 2.5em;
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
+
+    .stat-card .label {
+      opacity: 0.9;
+      font-size: 0.95em;
+    }
+
+    .stat-card .percentage {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 1px solid rgba(255,255,255,0.3);
+      font-size: 0.9em;
+    }
+
+    .chart-container {
+      background: white;
+      border: 2px solid #dee2e6;
+      border-radius: 12px;
+      padding: 25px;
+      margin-bottom: 25px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+    }
+
+    .chart-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 2px solid #dee2e6;
+    }
+
+    .chart-title {
+      font-size: 1.3em;
+      font-weight: 700;
+      color: #212529;
+    }
+
+    .chart-canvas {
+      width: 100%;
+      height: 300px;
+      position: relative;
+    }
+
+    .table-container {
+      background: white;
+      border: 2px solid #dee2e6;
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 25px;
+    }
+
+    .table-header {
+      background: #f8f9fa;
+      padding: 20px 25px;
+      border-bottom: 2px solid #dee2e6;
+    }
+
+    .table-title {
+      font-size: 1.3em;
+      font-weight: 700;
+      color: #212529;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 15px;
+      text-align: left;
+      border-bottom: 1px solid #dee2e6;
+    }
+
+    th {
+      background: #f8f9fa;
+      font-weight: 600;
+      color: #495057;
+      text-transform: uppercase;
+      font-size: 0.85em;
+      letter-spacing: 0.5px;
+    }
+
+    tr:hover {
+      background: #f8f9fa;
+    }
+
+    .progress-bar {
+      width: 100%;
+      height: 8px;
+      background: #e9ecef;
+      border-radius: 4px;
+      overflow: hidden;
+      margin-top: 5px;
+    }
+
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+      transition: width 0.3s;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      font-weight: 600;
+    }
+
+    .badge-success {
+      background: #d4edda;
+      color: #155724;
+    }
+
+    .badge-danger {
+      background: #f8d7da;
+      color: #721c24;
+    }
+
+    .badge-warning {
+      background: #fff3cd;
+      color: #856404;
+    }
+
+    .badge-info {
+      background: #d1ecf1;
+      color: #0c5460;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: #6c757d;
+    }
+
+    .empty-state svg {
+      width: 80px;
+      height: 80px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: #6c757d;
+    }
+
+    .spinner {
+      border: 3px solid #f3f3f3;
+      border-top: 3px solid #667eea;
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      animation: spin 1s linear infinite;
+      margin: 0 auto 15px;
+    }
+
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+
+    .info-box {
+      background: #e7f3ff;
+      border-left: 4px solid #2196F3;
+      padding: 15px;
+      border-radius: 6px;
+      color: #0c5460;
+      line-height: 1.5;
+      margin-bottom: 20px;
+    }
+
+    .chart-legend {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      margin-top: 20px;
+      flex-wrap: wrap;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .legend-color {
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+    }
+
+    @media (max-width: 768px) {
+      .header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .filter-row {
+        flex-direction: column;
+      }
+
+      .form-group {
+        width: 100%;
+      }
+
+      .dashboard-grid {
+        grid-template-columns: 1fr;
+      }
+
+      table {
+        font-size: 0.9em;
+      }
+
+      th, td {
+        padding: 10px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-left">
+        <h1>📊 Ata Akademi</h1>
+        <p>Raporlama ve Analiz Sistemi</p>
+      </div>
+      <div class="header-nav">
+        <a href="index.html" class="nav-btn">📝 Yoklama</a>
+        <a href="raporlar.html" class="nav-btn active">📊 Raporlar</a>
+      </div>
+    </div>
+
+    <div class="filters">
+      <div class="filter-row">
+        <div class="form-group">
+          <label for="reportType">Rapor Türü</label>
+          <select id="reportType">
+            <option value="class">Sınıf Bazlı Rapor</option>
+            <option value="date">Tarih Aralığı Raporu</option>
+            <option value="student">Öğrenci Detay Raporu</option>
+          </select>
+        </div>
+
+        <div class="form-group" id="classSelectGroup">
+          <label for="classSelect">Sınıf Seçin</label>
+          <select id="classSelect">
+            <option value="">Sınıf seçin...</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="startDate">Başlangıç Tarihi</label>
+          <input type="date" id="startDate" />
+        </div>
+
+        <div class="form-group">
+          <label for="endDate">Bitiş Tarihi</label>
+          <input type="date" id="endDate" />
+        </div>
+
+        <button class="btn btn-primary" id="generateReport">Rapor Oluştur</button>
+        <button class="btn btn-secondary" id="exportReport">📥 Dışa Aktar</button>
+      </div>
+    </div>
+
+    <div class="content">
+      <div id="dashboardStats" style="display: none;"></div>
+      <div id="chartSection" style="display: none;"></div>
+      <div id="reportContent"></div>
+    </div>
+  </div>
+
+  <script>
+    const REMOTE_API_BASE = 'https://ataakademiyoklama-eb98f60a1c26.herokuapp.com/api';
+    const LOCAL_API_BASE = 'http://localhost:3000/api';
+    
+    const API_BASE = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+      ? LOCAL_API_BASE
+      : REMOTE_API_BASE;
+
+    const defaultClassList = [
+      'TYT Sınıfı', '9. Sınıf', '10. Sınıf',
+      '11 Say 1', '11 Say 2', '11 Ea 1', '11 Ea 2',
+      '12 Say 1', '12 Say 2', '12 Say 3', '12 Ea 1', '12 Ea 2', '12 Ea 3',
+      'Mezun Ea 1', 'Mezun Ea 2', 'Mezun Ea 3',
+      'Mezun Say 1', 'Mezun Say 2', 'Mezun Say 3'
+    ];
+
+    const reportTypeSelect = document.getElementById('reportType');
+    const classSelect = document.getElementById('classSelect');
+    const startDate = document.getElementById('startDate');
+    const endDate = document.getElementById('endDate');
+    const generateBtn = document.getElementById('generateReport');
+    const exportBtn = document.getElementById('exportReport');
+    const dashboardStats = document.getElementById('dashboardStats');
+    const chartSection = document.getElementById('chartSection');
+    const reportContent = document.getElementById('reportContent');
+
+    let currentReportData = null;
+
+    init();
+
+    function init() {
+      setDefaultDates();
+      populateClassSelect();
+      generateBtn.addEventListener('click', generateReport);
+      exportBtn.addEventListener('click', exportReport);
+      reportTypeSelect.addEventListener('change', handleReportTypeChange);
+      handleReportTypeChange();
+      showWelcome();
+    }
+
+    function setDefaultDates() {
+      const today = new Date();
+      const lastWeek = new Date(today);
+      lastWeek.setDate(today.getDate() - 7);
+      
+      startDate.value = lastWeek.toISOString().split('T')[0];
+      endDate.value = today.toISOString().split('T')[0];
+    }
+
+    function populateClassSelect() {
+      classSelect.innerHTML = '<option value="">Tüm Sınıflar</option>';
+      defaultClassList.forEach(cls => {
+        const opt = document.createElement('option');
+        opt.value = cls;
+        opt.textContent = cls;
+        classSelect.appendChild(opt);
+      });
+    }
+
+    function handleReportTypeChange() {
+      const type = reportTypeSelect.value;
+      document.getElementById('classSelectGroup').style.display = 
+        type === 'student' ? 'none' : 'block';
+    }
+
+    function showWelcome() {
+      reportContent.innerHTML = `
+        <div class="empty-state">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+          </svg>
+          <h3>Raporlama Sistemi</h3>
+          <p>Rapor parametrelerini seçip "Rapor Oluştur" butonuna tıklayın.</p>
+        </div>
+      `;
+    }
+
+    async function generateReport() {
+      const type = reportTypeSelect.value;
+      const className = classSelect.value;
+      const start = startDate.value;
+      const end = endDate.value;
+
+      if (!start || !end) {
+        showToast('Lütfen tarih aralığı seçin', 'error');
+        return;
+      }
+
+      showLoading();
+
+      const mockData = generateMockData(type, className, start, end);
+      currentReportData = mockData;
+
+      setTimeout(() => {
+        displayDashboard(mockData.stats);
+        displayCharts(mockData);
+        displayReportTable(mockData);
+      }, 800);
+    }
+
+    function generateMockData(type, className, start, end) {
+      const dates = getDateRange(start, end);
+      const classes = className ? [className] : defaultClassList.slice(0, 5);
+      
+      const stats = {
+        totalStudents: classes.length * 25,
+        totalDays: dates.length,
+        avgAttendance: 87.5,
+        totalPresent: Math.floor(classes.length * 25 * dates.length * 0.875),
+        totalAbsent: Math.floor(classes.length * 25 * dates.length * 0.075),
+        totalExcused: Math.floor(classes.length * 25 * dates.length * 0.03),
+        totalPermitted: Math.floor(classes.length * 25 * dates.length * 0.02)
+      };
+
+      const classData = classes.map(cls => ({
+        className: cls,
+        totalStudents: 25,
+        present: Math.floor(25 * dates.length * 0.875),
+        absent: Math.floor(25 * dates.length * 0.075),
+        excused: Math.floor(25 * dates.length * 0.03),
+        permitted: Math.floor(25 * dates.length * 0.02),
+        attendanceRate: 87.5 + (Math.random() * 10 - 5)
+      }));
+
+      const dailyData = dates.map(date => ({
+        date,
+        present: Math.floor(classes.length * 25 * 0.875),
+        absent: Math.floor(classes.length * 25 * 0.075),
+        excused: Math.floor(classes.length * 25 * 0.03),
+        permitted: Math.floor(classes.length * 25 * 0.02)
+      }));
+
+      return { stats, classData, dailyData, type, className, dates };
+    }
+
+    function getDateRange(start, end) {
+      const dates = [];
+      const current = new Date(start);
+      const endDate = new Date(end);
+      
+      while (current <= endDate) {
+        dates.push(current.toISOString().split('T')[0]);
+        current.setDate(current.getDate() + 1);
+      }
+      
+      return dates;
+    }
+
+    function displayDashboard(stats) {
+      dashboardStats.innerHTML = `
+        <div class="dashboard-grid">
+          <div class="stat-card">
+            <div class="icon">👥</div>
+            <div class="number">${stats.totalStudents}</div>
+            <div class="label">Toplam Öğrenci</div>
+          </div>
+          <div class="stat-card">
+            <div class="icon">📅</div>
+            <div class="number">${stats.totalDays}</div>
+            <div class="label">Gün Sayısı</div>
+          </div>
+          <div class="stat-card">
+            <div class="icon">✅</div>
+            <div class="number">${stats.totalPresent}</div>
+            <div class="label">Toplam Geldi</div>
+            <div class="percentage">${stats.avgAttendance.toFixed(1)}% Devam Oranı</div>
+          </div>
+          <div class="stat-card">
+            <div class="icon">❌</div>
+            <div class="number">${stats.totalAbsent}</div>
+            <div class="label">Toplam Gelmedi</div>
+          </div>
+        </div>
+      `;
+      dashboardStats.style.display = 'block';
+    }
+
+    function displayCharts(data) {
+      chartSection.innerHTML = `
+        <div class="chart-container">
+          <div class="chart-header">
+            <div class="chart-title">Günlük Yoklama Trendi</div>
+          </div>
+          <div class="chart-canvas" id="trendChart"></div>
+          <div class="chart-legend">
+            <div class="legend-item">
+              <div class="legend-color" style="background: #28a745;"></div>
+              <span>Geldi</span>
+            </div>
+            <div class="legend-item">
+              <div class="legend-color" style="background: #dc3545;"></div>
+              <span>Gelmedi</span>
+            </div>
+            <div class="legend-item">
+              <div class="legend-color" style="background: #ffc107;"></div>
+              <span>Mazeretli</span>
+            </div>
+            <div class="legend-item">
+              <div class="legend-color" style="background: #17a2b8;"></div>
+              <span>İzinli</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="chart-container">
+          <div class="chart-header">
+            <div class="chart-title">Sınıf Bazlı Devam Oranları</div>
+          </div>
+          <div class="chart-canvas" id="classChart"></div>
+        </div>
+      `;
+
+      renderTrendChart(data.dailyData);
+      renderClassChart(data.classData);
+      chartSection.style.display = 'block';
+    }
+
+    function renderTrendChart(dailyData) {
+      const canvas = document.getElementById('trendChart');
+      const maxValue = Math.max(...dailyData.map(d => d.present + d.absent + d.excused + d.permitted));
+      const labels = dailyData.slice(-7).map(d => formatShortDate(d.date));
+      
+      canvas.innerHTML = `
+        <svg width="100%" height="100%" viewBox="0 0 800 300">
+          ${dailyData.slice(-7).map((d, i) => {
+            const x = 100 + i * 100;
+            const total = d.present + d.absent + d.excused + d.permitted;
+            const height = (total / maxValue) * 200;
+            return `
+              <rect x="${x - 30}" y="${250 - height}" width="60" height="${height}" 
+                    fill="url(#gradient)" rx="4" opacity="0.8"/>
+              <text x="${x}" y="270" text-anchor="middle" font-size="12" fill="#666">
+                ${formatShortDate(d.date)}
+              </text>
+              <text x="${x}" y="${240 - height}" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">
+                ${total}
+              </text>
+            `;
+          }).join('')}
+          <defs>
+            <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+              <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+            </linearGradient>
+          </defs>
+        </svg>
+      `;
+    }
+
+    function renderClassChart(classData) {
+      const canvas = document.getElementById('classChart');
+      const maxRate = 100;
+      
+      canvas.innerHTML = `
+        <svg width="100%" height="100%" viewBox="0 0 800 300">
+          ${classData.slice(0, 8).map((cls, i) => {
+            const y = 30 + i * 35;
+            const barWidth = (cls.attendanceRate / maxRate) * 600;
+            return `
+              <text x="10" y="${y + 15}" font-size="14" fill="#333">${cls.className}</text>
+              <rect x="150" y="${y}" width="${barWidth}" height="25" 
+                    fill="url(#gradient)" rx="4" opacity="0.8"/>
+              <text x="${160 + barWidth}" y="${y + 17}" font-size="13" font-weight="bold" fill="#333">
+                ${cls.attendanceRate.toFixed(1)}%
+              </text>
+            `;
+          }).join('')}
+        </svg>
+      `;
+    }
+
+    function displayReportTable(data) {
+      let html = `
+        <div class="table-container">
+          <div class="table-header">
+            <div class="table-title">Detaylı Yoklama Raporu</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Sınıf</th>
+                <th>Öğrenci Sayısı</th>
+                <th>Geldi</th>
+                <th>Gelmedi</th>
+                <th>Mazeretli</th>
+                <th>İzinli</th>
+                <th>Devam Oranı</th>
+                <th>Durum</th>
+              </tr>
+            </thead>
+            <tbody>
+      `;
+
+      data.classData.forEach(cls => {
+        const rate = cls.attendanceRate;
+        const badge = rate >= 90 ? 'success' : rate >= 75 ? 'warning' : 'danger';
+        const status = rate >= 90 ? 'Mükemmel' : rate >= 75 ? 'İyi' : 'Dikkat';
+        
+        html += `
+          <tr>
+            <td><strong>${cls.className}</strong></td>
+            <td>${cls.totalStudents}</td>
+            <td><span class="badge badge-success">${cls.present}</span></td>
+            <td><span class="badge badge-danger">${cls.absent}</span></td>
+            <td><span class="badge badge-warning">${cls.excused}</span></td>
+            <td><span class="badge badge-info">${cls.permitted}</span></td>
+            <td>
+              ${rate.toFixed(1)}%
+              <div class="progress-bar">
+                <div class="progress-fill" style="width: ${rate}%"></div>
+              </div>
+            </td>
+            <td><span class="badge badge-${badge}">${status}</span></td>
+          </tr>
+        `;
+      });
+
+      html += `
+            </tbody>
+          </table>
+        </div>
+      `;
+
+      reportContent.innerHTML = html;
+    }
+
+    function exportReport() {
+      if (!currentReportData) {
+        showToast('Önce rapor oluşturun', 'error');
+        return;
+      }
+
+      let csvContent = 'Sınıf,Öğrenci Sayısı,Geldi,Gelmedi,Mazeretli,İzinli,Devam Oranı\n';
+      
+      currentReportData.classData.forEach(cls => {
+        csvContent += `${cls.className},${cls.totalStudents},${cls.present},${cls.absent},${cls.excused},${cls.permitted},${cls.attendanceRate.toFixed(1)}%\n`;
+      });
+
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+      const link = document.createElement('a');
+      const url = URL.createObjectURL(blob);
+      link.setAttribute('href', url);
+      link.setAttribute('download', `yoklama_raporu_${new Date().toISOString().split('T')[0]}.csv`);
+      link.style.visibility = 'hidden';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      
+      showToast('Rapor başarıyla dışa aktarıldı', 'success');
+    }
+
+    function showLoading() {
+      reportContent.innerHTML = `
+        <div class="loading">
+          <div class="spinner"></div>
+          <p>Rapor oluşturuluyor...</p>
+        </div>
+      `;
+      dashboardStats.style.display = 'none';
+      chartSection.style.display = 'none';
+    }
+
+    function formatShortDate(dateStr) {
+      const date = new Date(dateStr + 'T00:00:00');
+      return date.toLocaleDateString('tr-TR', { day: '2-digit', month: '2-digit' });
+    }
+
+    function showToast(message, type = 'info') {
+      const toast = document.createElement('div');
+      toast.style.cssText = `
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        padding: 15px 25px;
+        background: ${type === 'success' ? '#28a745' : type === 'error' ? '#dc3545' : '#667eea'};
+        color: white;
+        border-radius: 8px;
+        box-shadow: 0 5px 20px rgba(0,0,0,0.3);
+        z-index: 9999;
+        animation: slideIn 0.3s ease;
+      `;
+      toast.textContent = message;
+      document.body.appendChild(toast);
+
+      setTimeout(() => {
+        toast.style.animation = 'slideOut 0.3s ease';
+        setTimeout(() => toast.remove(), 300);
+      }, 3000);
+    }
+
+    const style = document.createElement('style');
+    style.textContent = `
+      @keyframes slideIn {
+        from {
+          transform: translateX(100%);
+          opacity: 0;
+        }
+        to {
+          transform: translateX(0);
+          opacity: 1;
+        }
+      }
+      @keyframes slideOut {
+        from {
+          transform: translateX(0);
+          opacity: 1;
+        }
+        to {
+          transform: translateX(100%);
+          opacity: 0;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated raporlar.html reporting interface with filters, charts, and export capability
- update the attendance page header to include navigation buttons for attendance and reporting views

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4b6aa6178832b9d31705f471b199c