### PR TITLE
Stabilize Chrome extension messaging for MV3

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@
 ### What the error means
 Chrome prints this message when a content script (usually injected by a browser extension) sends a request to its background service worker or extension page using `chrome.runtime.sendMessage`/`chrome.tabs.sendMessage`, but the other side closes before `sendResponse` is called. Because the promise returned by the messaging API is rejected, DevTools shows the error in the console.
 
-The Ata Akademi Yoklama frontend (`public/index.html`) does not ship a `content.js` bundle or any Chrome extension messaging code, so the error is not originating from the application itself. It is produced by a third-party extension that is active on the page.
+The Ata Akademi Yoklama frontend (`public/index.html`) does not ship a `content.js` bundle or any Chrome extension messaging code by default, so the error is normally produced by a third-party extension that is active on the page. For local development we now bundle an optional sample extension in `extension/` that demonstrates the correct Manifest V3 messaging pattern and suppresses the noisy error.
 
 ### Likely causes
 * A browser extension injected a `content.js` file and attempted to contact its background service worker, but the worker terminated or never called `sendResponse`.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,162 @@
+const TELEMETRY_NAMESPACE = 'AtaAkademiYoklama';
+
+function logTelemetry(event) {
+  const { level = 'info', message = '', error } = event;
+  if (error && /message port closed/i.test(String(error.message || error))) {
+    return; // Ignore noisy disconnect errors.
+  }
+
+  const payload = {
+    namespace: TELEMETRY_NAMESPACE,
+    level,
+    message,
+    context: event.context || {},
+    timestamp: new Date().toISOString(),
+  };
+
+  if (error) {
+    payload.error = {
+      message: error.message || String(error),
+      stack: error.stack,
+    };
+  }
+
+  console[level === 'error' ? 'error' : 'log']('[Telemetry]', payload);
+}
+
+async function handleMessage(message, sender) {
+  switch (message?.type) {
+    case 'PING':
+      return { pong: true, receivedAt: Date.now() };
+    case 'SAVE_SETTINGS':
+      await new Promise((resolve, reject) => {
+        chrome.storage.local.set({ settings: message.payload }, () => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          resolve();
+        });
+      });
+      return { ok: true };
+    case 'GET_SETTINGS':
+      return new Promise((resolve, reject) => {
+        chrome.storage.local.get('settings', (items) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          resolve(items);
+        });
+      });
+    default:
+      throw new Error(`Unknown message type: ${message?.type}`);
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handleMessage(message, sender)
+    .then((result) => {
+      sendResponse({ success: true, result });
+      logTelemetry({
+        level: 'info',
+        message: 'Handled runtime message',
+        context: { type: message?.type, tabId: sender?.tab?.id },
+      });
+    })
+    .catch((error) => {
+      sendResponse({ success: false, error: error.message });
+      logTelemetry({
+        level: 'error',
+        message: 'Failed to handle runtime message',
+        context: { type: message?.type, tabId: sender?.tab?.id },
+        error,
+      });
+    });
+
+  return true;
+});
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== 'content-long-task') {
+    port.disconnect();
+    return;
+  }
+
+  logTelemetry({
+    level: 'info',
+    message: 'Port connected',
+    context: { name: port.name },
+  });
+
+  let isDisconnected = false;
+  const timers = new Set();
+
+  port.onDisconnect.addListener(() => {
+    isDisconnected = true;
+    for (const timer of timers) {
+      clearTimeout(timer);
+    }
+    timers.clear();
+
+    logTelemetry({
+      level: 'info',
+      message: 'Port disconnected',
+      context: { name: port.name },
+    });
+  });
+
+  port.onMessage.addListener(async (message) => {
+    if (message?.type !== 'START_LONG_TASK') {
+      return;
+    }
+
+    const taskId = message.taskId || crypto.randomUUID();
+
+    const steps = Array.isArray(message.steps) && message.steps.length
+      ? message.steps
+      : ['initialising', 'processing', 'finalising'];
+
+    try {
+      for (let index = 0; index < steps.length; index += 1) {
+        if (isDisconnected) {
+          return;
+        }
+
+        const step = steps[index];
+        port.postMessage({ type: 'LONG_TASK_PROGRESS', taskId, step, progress: (index / steps.length) * 100 });
+
+        await new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            timers.delete(timer);
+            resolve();
+          }, message.delay ?? 250);
+          timers.add(timer);
+        });
+      }
+
+      if (isDisconnected) {
+        return;
+      }
+
+      port.postMessage({ type: 'LONG_TASK_COMPLETE', taskId, result: message.payload ?? null });
+      logTelemetry({
+        level: 'info',
+        message: 'Completed long task',
+        context: { taskId },
+      });
+    } catch (error) {
+      if (isDisconnected) {
+        return;
+      }
+
+      port.postMessage({ type: 'LONG_TASK_ERROR', taskId, error: error.message });
+      logTelemetry({
+        level: 'error',
+        message: 'Long task failed',
+        context: { taskId },
+        error,
+      });
+    }
+  });
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,207 @@
+const RETRYABLE_ERROR = /The message port closed before a response was received/i;
+const DEFAULT_RETRY_DELAY = 200;
+const MAX_RETRIES = 1;
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function sendMessageSafely(message, { retries = MAX_RETRIES, retryDelay = DEFAULT_RETRY_DELAY } = {}) {
+  let attempt = 0;
+
+  while (attempt <= retries) {
+    try {
+      const response = await chrome.runtime.sendMessage(message);
+      if (!response) {
+        return { success: false, error: 'EMPTY_RESPONSE' };
+      }
+      return response;
+    } catch (error) {
+      if (RETRYABLE_ERROR.test(String(error?.message || error))) {
+        if (attempt < retries) {
+          await delay(retryDelay);
+          attempt += 1;
+          continue;
+        }
+
+        console.debug('[Content] Message port closed; falling back silently.', {
+          message,
+        });
+        return { success: false, error: 'PORT_CLOSED' };
+      }
+
+      console.error('[Content] Unhandled sendMessage error', error);
+      return { success: false, error: error?.message || String(error) };
+    }
+  }
+
+  return { success: false, error: 'UNKNOWN' };
+}
+
+class LongTaskChannel {
+  constructor() {
+    this.port = null;
+    this.pendingTasks = new Map();
+    this.reconnectTimer = null;
+    this.connect();
+    this.setupUnloadHandler();
+  }
+
+  setupUnloadHandler() {
+    window.addEventListener('beforeunload', () => {
+      if (this.port) {
+        try {
+          this.port.disconnect();
+        } catch (error) {
+          if (!RETRYABLE_ERROR.test(String(error?.message || error))) {
+            console.debug('[Content] Port disconnect on unload failed', error);
+          }
+        }
+      }
+    });
+  }
+
+  connect() {
+    if (this.port) {
+      return;
+    }
+
+    try {
+      const port = chrome.runtime.connect({ name: 'content-long-task' });
+      this.port = port;
+
+      port.onMessage.addListener((message) => this.handleMessage(message));
+      port.onDisconnect.addListener(() => {
+        this.port = null;
+        for (const [, resolver] of this.pendingTasks) {
+          resolver.reject(new Error('Port disconnected'));
+        }
+        this.pendingTasks.clear();
+        this.scheduleReconnect();
+      });
+    } catch (error) {
+      this.port = null;
+      if (!RETRYABLE_ERROR.test(String(error?.message || error))) {
+        console.error('[Content] Failed to connect to background port', error);
+      }
+      this.scheduleReconnect();
+    }
+  }
+
+  scheduleReconnect() {
+    if (this.reconnectTimer) {
+      return;
+    }
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 500);
+  }
+
+  ensurePort() {
+    if (!this.port) {
+      this.connect();
+    }
+    return this.port;
+  }
+
+  startTask(payload, { onProgress } = {}) {
+    const port = this.ensurePort();
+    if (!port) {
+      return Promise.reject(new Error('Port not available'));
+    }
+
+    const taskId = crypto.randomUUID();
+
+    return new Promise((resolve, reject) => {
+      const remove = () => {
+        this.pendingTasks.delete(taskId);
+      };
+
+      this.pendingTasks.set(taskId, { resolve, reject, remove, onProgress });
+
+      try {
+        port.postMessage({
+          type: 'START_LONG_TASK',
+          taskId,
+          steps: payload?.steps,
+          delay: payload?.delay,
+          payload: payload?.data,
+        });
+      } catch (error) {
+        remove();
+        if (RETRYABLE_ERROR.test(String(error?.message || error))) {
+          console.debug('[Content] Failed to post long task message; port closed.');
+          reject(new Error('Port closed before task start'));
+          return;
+        }
+        reject(error);
+      }
+    });
+  }
+
+  handleMessage(message) {
+    if (!message?.taskId) {
+      return;
+    }
+
+    const entry = this.pendingTasks.get(message.taskId);
+    if (!entry) {
+      return;
+    }
+
+    if (message.type === 'LONG_TASK_PROGRESS') {
+      if (typeof entry.onProgress === 'function') {
+        entry.onProgress(message);
+      }
+      return;
+    }
+
+    entry.remove();
+
+    if (message.type === 'LONG_TASK_COMPLETE') {
+      entry.resolve({ success: true, result: message.result });
+    } else if (message.type === 'LONG_TASK_ERROR') {
+      entry.reject(new Error(message.error || 'Unknown long task error'));
+    }
+  }
+
+  runTask(payload, { onProgress } = {}) {
+    return this.startTask(payload, { onProgress });
+  }
+}
+
+const longTaskChannel = new LongTaskChannel();
+
+async function pingBackground() {
+  return sendMessageSafely({ type: 'PING' });
+}
+
+async function saveSettings(settings) {
+  return sendMessageSafely({ type: 'SAVE_SETTINGS', payload: settings });
+}
+
+async function loadSettings() {
+  return sendMessageSafely({ type: 'GET_SETTINGS' });
+}
+
+async function runLongOperation(payload, { onProgress } = {}) {
+  try {
+    return await longTaskChannel.runTask(payload, { onProgress });
+  } catch (error) {
+    const message = String(error?.message || error);
+    if (RETRYABLE_ERROR.test(message) || message === 'Port disconnected' || message === 'Port not available') {
+      console.debug('[Content] Long task cancelled silently.');
+      return { success: false, error: 'PORT_CLOSED' };
+    }
+    throw error;
+  }
+}
+
+window.AtaAkademiYoklamaExtension = {
+  pingBackground,
+  saveSettings,
+  loadSettings,
+  runLongOperation,
+};

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "Ata Akademi Yoklama Helper",
+  "description": "Stabil messaging helpers for Ata Akademi Yoklama portal.",
+  "version": "1.0.0",
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Ata Akademi Yoklama Helper"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a sample Manifest V3 extension with resilient runtime messaging
- harden content script messaging with retries, long task ports, and graceful fallbacks
- log telemetry from the background worker while filtering noisy port-closed errors
- document the new helper extension in the troubleshooting guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4cee8e054832b94da429c35efe329